### PR TITLE
Make binaries executable

### DIFF
--- a/.semaphore/cmd/repackage-sensu-go-agent-deb.sh
+++ b/.semaphore/cmd/repackage-sensu-go-agent-deb.sh
@@ -13,6 +13,7 @@ pushd sensu-go-agent
 # Swap out the binary
 rm usr/sbin/sensu-agent
 artifact pull workflow sensu-agent --destination usr/sbin/sensu-agent
+chmod 755 usr/sbin/sensu-agent
 
 # Update md5sum with new binary's hash
 sed '/usr\/sbin\/sensu-agent/d' -i'' DEBIAN/md5sums

--- a/.semaphore/cmd/repackage-sensu-go-backend-deb.sh
+++ b/.semaphore/cmd/repackage-sensu-go-backend-deb.sh
@@ -13,6 +13,7 @@ pushd sensu-go-backend
 # Swap out the binary
 rm usr/sbin/sensu-backend
 artifact pull workflow sensu-backend --destination usr/sbin/sensu-backend
+chmod 755 usr/sbin/sensu-backend
 
 # Update md5sum with new binary's hash
 sed '/usr\/sbin\/sensu-backend/d' -i'' DEBIAN/md5sums

--- a/.semaphore/cmd/repackage-sensu-go-cli-deb.sh
+++ b/.semaphore/cmd/repackage-sensu-go-cli-deb.sh
@@ -13,6 +13,7 @@ pushd sensu-go-cli
 # Swap out the binary
 rm usr/bin/sensuctl
 artifact pull workflow sensuctl --destination usr/bin/sensuctl
+chmod 755 usr/bin/sensuctl
 
 # Update md5sum with new binary's hash
 sed '/usr\/bin\/sensuctl/d' -i'' DEBIAN/md5sums


### PR DESCRIPTION
## What?

- [x] Added an explicit chmod to community edition binaries we swap in

## Why?

Turns out once they've roundtripped through artifact storage they aren't anymore, which then leads to tooling not working on the servers. Oops.